### PR TITLE
Add operations of MaxPane to command pallet

### DIFF
--- a/max_paine.sublime-commands
+++ b/max_paine.sublime-commands
@@ -1,0 +1,14 @@
+[
+  {
+    "caption": "Maximize/Unmaximize pane",
+    "command": "max_pane"
+  },
+  {
+    "caption": "Switch to next pane",
+    "command": "shift_pane"
+  },
+  {
+    "caption": "Switch to previous pane",
+    "command": "unshift_pane"
+  }
+]


### PR DESCRIPTION
This is useful for windows/linux users that haven't mapped the commands to shortcuts, they can still use the commands right after installing.  Having the operations in the command pallet is also useful for users that aren't utilizing MaxPane often.