### PR TITLE
extend unmaximize_before variable, to prevent potential crashes caused by layout changes

### DIFF
--- a/max_pane.py
+++ b/max_pane.py
@@ -30,8 +30,8 @@ class ShareManager:
         cls.check_and_submit()
 
 # ------
- 
-    
+
+
 class PaneManager:
     layouts = {}
     maxgroup = {}
@@ -196,7 +196,12 @@ class MaxPaneEvents(sublime_plugin.EventListener):
     def on_window_command(self, window, command_name, args):
         unmaximize_before = ["travel_to_pane", "carry_file_to_pane",
                              "clone_file_to_pane", "create_pane",
-                             "destroy_pane", "create_pane_with_file"]
+                             "destroy_pane", "create_pane_with_file",
+                             "set_layout", "project_manager", "new_pane"]
+
+        if sublime.load_settings(SHARE_OBJECT).get('block_max_pane'):
+            return None
+
         if command_name in unmaximize_before:
             window.run_command("unmaximize_pane")
 
@@ -209,6 +214,10 @@ class MaxPaneEvents(sublime_plugin.EventListener):
         return None
 
     def on_activated(self, view):
+
+        if sublime.load_settings(SHARE_OBJECT).get('block_max_pane'):
+            return None
+
         w = view.window() or sublime.active_window()
         # Is the window currently maximized?
         if w and PaneManager.isWindowMaximized(w):


### PR DESCRIPTION
Also introduced a setting check to prevent MaxPane from handling the layout, if this needs to be avoided the new variable must be set to True externally, and also reset externally to False, so that MaxPane can resume its normal behaviour