### PR TITLE
Resolve conflict with default key bindings

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,3 +1,3 @@
 [
-    { "keys": ["ctrl+shift+enter"], "command": "max_pane" }
+    { "keys": ["ctrl+k", "ctrl+f"], "command": "max_pane" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,5 +1,5 @@
 [
-    { "keys": ["super+shift+enter"], "command": "max_pane" },
-    { "keys": ["super+ctrl+right"], "command": "shift_pane" },
-    { "keys": ["super+ctrl+left"], "command": "unshift_pane" }
+    { "keys": ["super+k", "super+f"], "command": "max_pane" },
+	{ "keys": ["super+ctrl+right"], "command": "shift_pane" },
+	{ "keys": ["super+ctrl+left"], "command": "unshift_pane" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,3 +1,3 @@
 [
-    { "keys": ["ctrl+shift+enter"], "command": "max_pane" }
+    { "keys": ["ctrl+k", "ctrl+f"], "command": "max_pane" }
 ]

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ So lets say you have this multi pane setup:
 
 and you want to maximize the active (top left) pane for a sec.
 
-Just press <kbd>cmd + shift + enter</kbd> and the active pane is now maximized:
+Just press <kbd>ctrl + k</kbd>, <kbd>ctrl + f</kbd> _(Linux/Windows)_ / <kbd>super + k</kbd>, <kbd>super + f</kbd> _(MacOS)_ and the active pane is now maximized:
 
 ![single pane](https://raw.github.com/jisaacks/MaxPane/3535650829f9bbb7df2d26428589b9bd47b13591/after.png)
 
-Press <kbd>cmd + shift + enter</kbd> another time and its back:
+Press <kbd>ctrl + k</kbd>, <kbd>ctrl + f</kbd> _(Linux/Windows)_ / <kbd>super + k</kbd>, <kbd>super + f</kbd> _(MacOS)_ another time and its back:
 
 ![dual pane](https://raw.github.com/jisaacks/MaxPane/3535650829f9bbb7df2d26428589b9bd47b13591/before.png)
 


### PR DESCRIPTION
Closes #3
Fixes  #9

The currently used `ctrl+shift+enter` is already assigned to the `add_line_before` command in Sublime Text 3's Default package.

This commit resolves this conflict by binding the `max_pane` command to

  MacOS:         `super+k`, `super+f`
  Windows/Linux: `ctrl+k`, `ctrl+f`

as

1) this binding is not currently used by vanilla ST3 or Origami plugin.
2) the sequence ctrl+k, ctrl+... is used for various pane and layout related functions like `focus_neighbouring_group`, `move_to_neighbouring_group` or `toggle_sidebar` in Sublime Text or Origami plugin.

Note:
  The key bindings for `shift_pane` and `unshift_pane` on MacOS are kept unchanged for compatibility reasons with ST2 and iTerm behavior.

  New bindings for Linux/Windows are not added because ST3 provides these functions and proper bindings out of the box, which deprecates both functions.